### PR TITLE
fix: roomDictionary not populating properly

### DIFF
--- a/src/services/Room.ts
+++ b/src/services/Room.ts
@@ -35,7 +35,7 @@ export class RoomService {
         room.memory.t = Roomtype.Normal;
       }
 
-      if (rooms[room.memory.t]) {
+      if (!rooms[room.memory.t]) {
         rooms[room.memory.t] = [];
       }
       rooms[room.memory.t].push(room);


### PR DESCRIPTION
Fix typo in RoomService causes the Room Dictionary to not populate properly.
This results in other functions, notably `roomService.getNormalRooms()` to return only one room, instead of all normal rooms.